### PR TITLE
chore: auto-merge 주간 머지 기본값을 3으로 변경

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -105,10 +105,10 @@ jobs:
             });
 
             // PR 개수에 따라 MAX_WEEKLY_MERGES 설정
-            let MAX_WEEKLY_MERGES = 1;
-            if (eligiblePRs.length >= 5) MAX_WEEKLY_MERGES = 2;
-            if (eligiblePRs.length >= 10) MAX_WEEKLY_MERGES = 3;
-            if (eligiblePRs.length >= 15) MAX_WEEKLY_MERGES = 4;
+            let MAX_WEEKLY_MERGES = 3;
+            if (eligiblePRs.length >= 10) MAX_WEEKLY_MERGES = 4;
+            if (eligiblePRs.length >= 15) MAX_WEEKLY_MERGES = 5;
+            if (eligiblePRs.length >= 20) MAX_WEEKLY_MERGES = 6;
 
             // 지난 7일간 merge 된 PR 개수 확인
             const { data: mergedPRs } = await github.rest.pulls.list({


### PR DESCRIPTION
## Summary
- `MAX_WEEKLY_MERGES` 기본값을 1에서 3으로 상향 조정
- 단계별 임계값 조정: eligible PR 10개 이상→4, 15개 이상→5, 20개 이상→6

## Test plan
- [ ] Auto Merge PRs 워크플로우 수동 실행하여 주간 제한 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)