### PR TITLE
fix: fix-post-date 워크플로우에 exclude_dirs 파라미터 추가

### DIFF
--- a/.github/workflows/fix-post-date.yml
+++ b/.github/workflows/fix-post-date.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
         default: ''
+      exclude_dirs:
+        required: false
+        type: string
+        default: ''
+        description: '날짜 보정에서 제외할 디렉토리 (쉼표 구분, 예: contents/biweekly,contents/archive)'
 
 jobs:
   fix-post-date:
@@ -41,9 +46,11 @@ jobs:
 
             // index.md 파일만 필터링 (content_dir이 지정되면 해당 경로만 대상)
             const contentDir = '${{ inputs.content_dir }}';
+            const excludeDirs = '${{ inputs.exclude_dirs }}'.split(',').map(d => d.trim()).filter(Boolean);
             const indexFiles = files.filter(f => {
               if (!f.filename.endsWith('index.md')) return false;
               if (contentDir && !f.filename.startsWith(contentDir + '/')) return false;
+              if (excludeDirs.some(dir => f.filename.startsWith(dir + '/'))) return false;
               return true;
             });
 


### PR DESCRIPTION
## Summary
- `fix-post-date` 재사용 워크플로우에 `exclude_dirs` 입력 파라미터 추가
- 쉼표 구분으로 여러 디렉토리를 날짜 보정 대상에서 제외 가능
- biweekly 뉴스처럼 의도적으로 과거/미래 날짜를 사용하는 콘텐츠가 잘못 보정되는 문제 해결 (PR #453 원인)

## Test plan
- [ ] `exclude_dirs`가 비어있을 때 기존 동작과 동일한지 확인
- [ ] `exclude_dirs: contents/biweekly` 설정 시 biweekly 하위 파일이 보정 대상에서 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)