### PR TITLE
fix: fix-post-date 과거 날짜는 보정에서 제외

### DIFF
--- a/.github/workflows/fix-post-date.yml
+++ b/.github/workflows/fix-post-date.yml
@@ -71,10 +71,11 @@ jobs:
                 const fileContent = Buffer.from(content.content, 'base64').toString('utf-8');
                 const dateMatch = fileContent.match(/^---[\s\S]*?date:\s*(\d{4}-\d{2}-\d{2})[\s\S]*?---/);
 
-                if (dateMatch && dateMatch[1] !== today) {
-                  const label = dateMatch[1] > today ? '미래' : '과거';
-                  console.log(`${label} 날짜 감지: ${file.filename} (date: ${dateMatch[1]})`);
+                if (dateMatch && dateMatch[1] > today) {
+                  console.log(`미래 날짜 감지: ${file.filename} (date: ${dateMatch[1]})`);
                   filesToFix.push({ path: file.filename, oldDate: dateMatch[1] });
+                } else if (dateMatch && dateMatch[1] < today) {
+                  console.log(`과거 날짜 (의도된 것으로 간주, 스킵): ${file.filename} (date: ${dateMatch[1]})`);
                 } else {
                   console.log(`정상: ${file.filename} (date: ${dateMatch ? dateMatch[1] : 'N/A'})`);
                 }
@@ -179,7 +180,7 @@ jobs:
               title: '[chore] 포스팅 날짜를 현재 날짜로 보정',
               head: branchName,
               base: 'main',
-              body: `PR #${prNumber} merge 시 오늘과 다른 날짜가 감지되어 자동 보정합니다.\n\n### 변경 파일\n${changedFiles.join('\n')}`
+              body: `PR #${prNumber} merge 시 미래 날짜가 감지되어 오늘 날짜로 자동 보정합니다.\n\n### 변경 파일\n${changedFiles.join('\n')}`
             });
 
             console.log(`PR 생성 완료: #${pr.number} (${pr.html_url})`);


### PR DESCRIPTION
## Summary
- `fix-post-date` 워크플로우에서 과거 날짜는 의도된 작성일로 간주하여 보정 대상에서 제외
- 미래 날짜만 PR 머지 시점의 오늘 날짜로 자동 보정
- 보정 PR 본문 문구를 "미래 날짜가 감지되어 오늘 날짜로 자동 보정합니다"로 정확히 표현

## Background
기존 동작은 오늘과 다른 모든 날짜(과거/미래 모두)를 오늘 날짜로 덮어썼다.
하지만 과거 날짜는 작성자가 의도해서 지정한 작성일인 경우가 많아, 머지 시점에 강제로 변경되면 원래 의도가 사라진다.
미래 날짜만 보정 대상으로 삼아 사용자의 의도를 보존한다.

## Changes
- `dateMatch[1] !== today` → `dateMatch[1] > today` 조건으로 변경 (Step 1: `fix-dates`)
- 과거 날짜는 `filesToFix`에 추가하지 않고 "스킵" 로그만 남김
- 보정 PR body 문구 갱신

## Side Effect
과거 날짜 포스트는 Step 2(보정 PR 생성)에 진입하지 않으므로 `update:` 필드도 그대로 보존됨.

## Test plan
- [ ] 미래 날짜(`date: 2099-01-01`)가 포함된 PR 머지 시 자동 보정 PR이 생성되는지 확인
- [ ] 과거 날짜(`date: 2020-01-01`)가 포함된 PR 머지 시 보정 PR이 생성되지 않는지 확인 (스킵 로그만 출력)
- [ ] 오늘 날짜인 경우 "정상" 로그만 출력되는지 확인
- [ ] 미래 날짜와 과거 날짜가 섞인 PR에서 미래 날짜 파일만 보정되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)